### PR TITLE
Added types in `dist`

### DIFF
--- a/dist/FingerDescription.d.ts
+++ b/dist/FingerDescription.d.ts
@@ -1,0 +1,57 @@
+declare const Finger: {
+    Thumb: number;
+    Index: number;
+    Middle: number;
+    Ring: number;
+    Pinky: number;
+    all: number[];
+    nameMapping: {
+        0: string;
+        1: string;
+        2: string;
+        3: string;
+        4: string;
+    };
+    pointsMapping: {
+        0: number[][];
+        1: number[][];
+        2: number[][];
+        3: number[][];
+        4: number[][];
+    };
+    getName: (value: any) => any;
+    getPoints: (value: any) => any;
+};
+declare const FingerCurl: {
+    NoCurl: number;
+    HalfCurl: number;
+    FullCurl: number;
+    nameMapping: {
+        0: string;
+        1: string;
+        2: string;
+    };
+    getName: (value: any) => any;
+};
+declare const FingerDirection: {
+    VerticalUp: number;
+    VerticalDown: number;
+    HorizontalLeft: number;
+    HorizontalRight: number;
+    DiagonalUpRight: number;
+    DiagonalUpLeft: number;
+    DiagonalDownRight: number;
+    DiagonalDownLeft: number;
+    nameMapping: {
+        0: string;
+        1: string;
+        2: string;
+        3: string;
+        4: string;
+        5: string;
+        6: string;
+        7: string;
+    };
+    getName: (value: any) => any;
+};
+export { Finger, FingerCurl, FingerDirection };

--- a/dist/FingerPoseEstimator.d.ts
+++ b/dist/FingerPoseEstimator.d.ts
@@ -1,0 +1,16 @@
+export default class FingerPoseEstimator {
+    constructor(options: any);
+    options: any;
+    estimate(landmarks: any): {
+        curls: number[];
+        directions: number[];
+    };
+    getSlopes(point1: any, point2: any): number | number[];
+    angleOrientationAt(angle: any, weightageAt?: number): number[];
+    estimateFingerCurl(startPoint: any, midPoint: any, endPoint: any): number;
+    estimateHorizontalDirection(start_end_x_dist: any, start_mid_x_dist: any, mid_end_x_dist: any, max_dist_x: any): number;
+    estimateVerticalDirection(start_end_y_dist: any, start_mid_y_dist: any, mid_end_y_dist: any, max_dist_y: any): number;
+    estimateDiagonalDirection(start_end_y_dist: any, start_mid_y_dist: any, mid_end_y_dist: any, max_dist_y: any, start_end_x_dist: any, start_mid_x_dist: any, mid_end_x_dist: any, max_dist_x: any): number;
+    calculateFingerDirection(startPoint: any, midPoint: any, endPoint: any, fingerSlopes: any): number;
+    calculateSlope(point1x: any, point1y: any, point2x: any, point2y: any): number;
+}

--- a/dist/GestureDescription.d.ts
+++ b/dist/GestureDescription.d.ts
@@ -1,0 +1,9 @@
+export default class GestureDescription {
+  constructor(name: string);
+  name: string;
+  curls: {};
+  directions: {};
+  addCurl(finger: any, curl: any, contrib?: number): void;
+  addDirection(finger: any, position: any, contrib?: number): void;
+  matchAgainst(detectedCurls: any, detectedDirections: any): number;
+}

--- a/dist/GestureEstimator.d.ts
+++ b/dist/GestureEstimator.d.ts
@@ -1,0 +1,13 @@
+export default class GestureEstimator {
+    constructor(knownGestures: any, estimatorOptions?: {});
+    estimator: FingerPoseEstimator;
+    gestures: any;
+    estimate(landmarks: any, minScore: any): {
+        poseData: any[][];
+        gestures: {
+            name: any;
+            score: any;
+        }[];
+    };
+}
+import FingerPoseEstimator from "./FingerPoseEstimator";

--- a/dist/gestures/ThumbsUp.d.ts
+++ b/dist/gestures/ThumbsUp.d.ts
@@ -1,0 +1,3 @@
+export default thumbsUpDescription;
+declare const thumbsUpDescription: GestureDescription;
+import GestureDescription from "../GestureDescription";

--- a/dist/gestures/Victory.d.ts
+++ b/dist/gestures/Victory.d.ts
@@ -1,0 +1,3 @@
+export default victoryDescription;
+declare const victoryDescription: GestureDescription;
+import GestureDescription from "../GestureDescription";

--- a/dist/gestures/index.d.ts
+++ b/dist/gestures/index.d.ts
@@ -1,0 +1,3 @@
+import VictoryGesture from "./Victory";
+import ThumbsUpGesture from "./ThumbsUp";
+export { VictoryGesture, ThumbsUpGesture };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,15 @@
+declare namespace _default {
+    export { GestureEstimator };
+    export { GestureDescription };
+    export { Finger };
+    export { FingerCurl };
+    export { FingerDirection };
+    export { Gestures };
+}
+export default _default;
+import GestureEstimator from "./GestureEstimator";
+import GestureDescription from "./GestureDescription";
+import { Finger } from "./FingerDescription";
+import { FingerCurl } from "./FingerDescription";
+import { FingerDirection } from "./FingerDescription";
+import * as Gestures from "./gestures";


### PR DESCRIPTION
Here is generated types from `tsc` command, not everything has types yet but is enough to be very usable with typescript. ill complete the types soon

### Steps done
1. create a `tsconfig.json` file with this content
```json
{
  "include": [
    "src/**/*"
  ],
  "compilerOptions": {
    "allowJs": true,
    "declaration": true,
    "emitDeclarationOnly": true,
    "outDir": "dist"
  }
}
```

2. run `npx tsc` in root dir
3. change types of obvious params like `name` which should be string